### PR TITLE
docs: add central README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+## Pull Request: Add Central README for OctoAcme Project Management Docs
+
+This PR adds a new `README.md` file to the `docs/` folder. The README centralizes direct links to all OctoAcme project management process documents and provides a summary of the project management approach. It improves discoverability and onboarding for new and existing team members, ensuring equal access to structured, versioned process knowledge.
+
+### README Content Preview
+
+```markdown
+docs/README.md
+
+# OctoAcme Project Management Docs
+
+This folder contains OctoAcme's project management processes. These are living documents intended to centralize process knowledge, improve onboarding, reduce single-person dependencies, and make our practices discoverable and versioned.
+
+## Project Management Process Summary
+
+OctoAcme follows a structured, repeatable approach to delivering projects with clarity and continuous improvement:
+
+- Project initiation: Define goals, scope, stakeholders, and initial success criteria to ensure projects start with alignment and governance.
+- Project planning: Build a realistic plan that includes scope breakdown, schedules, resourcing, and required artifacts for visibility and coordination.
+- Execution and tracking: Use defined tracking cadences (status updates, backlog refinement, sprint planning or equivalent) to manage progress, dependencies, and deliverables.
+- Risk management and communication: Proactively identify, assess, and mitigate risks and keep stakeholders informed with clear communication protocols and escalation paths.
+- Release and deployment: Follow standardized release checklists and deployment steps to ensure quality and traceability during handoffs to production.
+- Retrospective and continuous improvement: Capture lessons learned, define action items, and iterate on processes to improve outcomes over time.
+- Roles and personas: Clarify responsibilities and expectations for core roles (product, engineering, PM, QA, operations, stakeholders) to reduce handoff friction.
+
+These processes are practical and adaptable; teams should apply what fits their context and propose improvements to the living documents.
+
+## Process Docs Index
+
+- [Project Management Overview](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-management-overview.md)
+- [Project Initiation](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-initiation.md)
+- [Project Planning](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-planning.md)
+- [Execution and Tracking](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-execution-and-tracking.md)
+- [Risks and Communication](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-risks-and-communication.md)
+- [Release and Deployment](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-release-and-deployment.md)
+- [Retrospective and Continuous Improvement](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](https://github.com/SenthilValliappan85/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-roles-and-personas.md)
+
+## Acceptance Criteria
+
+- [ ] Content aligns with existing process docs
+- [ ] Update improves clarity or closes a documented gap
+- [ ] Proposed content has been reviewed with stakeholders (if needed)
+```
+
+---
+
+**Reviewer:** @SenthilValliappan85
+**Related Issue:** #2
+
+---
+
+This PR is ready for review and will help centralize all project management process docs in one place for the OctoAcme team.


### PR DESCRIPTION
This README centralizes links to all OctoAcme project management process documents and summarizes the project management approach, improving discoverability and onboarding for team members.